### PR TITLE
アクティビティの量（色表示）の凡例

### DIFF
--- a/renderer/src/components/legend/Legend.tsx
+++ b/renderer/src/components/legend/Legend.tsx
@@ -1,21 +1,29 @@
 import { CellContainer } from '../cell'
 
-const Component: React.VFC = () => {
+type Props = {
+    /**
+     * What class to be used for Legend
+     */
+    className: string
+}
+
+const Component: React.VFC<Props> = (props) => {
+    const textSize = 'text-xs'
 	return (
-		<>
-			<div>Low</div>
+		<div className={props.className}>
+			<div className={textSize}>Low</div>
 			<CellContainer stack={0} />
 			<CellContainer stack={25} />
 			<CellContainer stack={50} />
 			<CellContainer stack={75} />
 			<CellContainer stack={100} />
-			<div>High</div>
-		</>
+			<div className={textSize}>High</div>
+        </div>
 	)
 }
 
 export const StyledComponent: React.VFC = () => {
-	return <Component />
+	return <Component className="flex flex-row space-x-1" />
 }
 
 export const Container: React.VFC = () => {

--- a/renderer/src/components/legend/Legend.tsx
+++ b/renderer/src/components/legend/Legend.tsx
@@ -1,0 +1,23 @@
+import { CellContainer } from '../cell'
+
+const Component: React.VFC = () => {
+	return (
+		<>
+			<div>Low</div>
+			<CellContainer stack={0} />
+			<CellContainer stack={25} />
+			<CellContainer stack={50} />
+			<CellContainer stack={75} />
+			<CellContainer stack={100} />
+			<div>High</div>
+		</>
+	)
+}
+
+export const StyledComponent: React.VFC = () => {
+	return <Component />
+}
+
+export const Container: React.VFC = () => {
+	return <StyledComponent />
+}

--- a/renderer/src/components/legend/index.stories.tsx
+++ b/renderer/src/components/legend/index.stories.tsx
@@ -1,0 +1,11 @@
+import { Story, Meta } from '@storybook/react'
+import { LegendContainer } from './index'
+
+export default {
+	title: 'components/Legend',
+	component: LegendContainer,
+} as Meta
+
+const Template: Story = () => <LegendContainer />
+
+export const LegendTest = Template.bind({})

--- a/renderer/src/components/legend/index.ts
+++ b/renderer/src/components/legend/index.ts
@@ -1,0 +1,2 @@
+
+export { Container as LegendContainer } from './Legend'


### PR DESCRIPTION
- Show legend from low to high, like github commit contribution